### PR TITLE
fix: remove jsr slow types

### DIFF
--- a/.changeset/funny-ladybugs-perform.md
+++ b/.changeset/funny-ladybugs-perform.md
@@ -1,0 +1,5 @@
+---
+"@r4ai/remark-embed": minor
+---
+
+Fix jsr slow types

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Publish to JSR
         if: steps.changesets.outputs.published == 'true'
-        run: bun run jsr publish --allow-slow-types
+        run: bun run jsr publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Publish dry run (check "slow types" and so on)
-        run: bun run jsr publish --dry-run --allow-slow-types
+        run: bun run jsr publish --dry-run

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,6 @@
         "remark-parse": "11.0.0",
         "remark-rehype": "11.1.1",
         "rimraf": "6.0.1",
-        "ts-essentials": "10.0.4",
         "typescript": "5.7.3",
         "unified": "11.0.5",
         "vitest": "3.0.5",
@@ -797,8 +796,6 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
-
-    "ts-essentials": ["ts-essentials@10.0.4", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A=="],
 
     "type-fest": ["type-fest@4.26.1", "", {}, "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg=="],
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "remark-parse": "11.0.0",
     "remark-rehype": "11.1.1",
     "rimraf": "6.0.1",
-    "ts-essentials": "10.0.4",
     "typescript": "5.7.3",
     "unified": "11.0.5",
     "vitest": "3.0.5"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "changeset": "changeset",
     "changeset:version": "changeset version && bun run .github/scripts/sync-package-version.ts",
-    "release": "bun run build && bun run jsr publish --dry-run --allow-slow-types && bun run changeset publish"
+    "release": "bun run build && bun run jsr publish --dry-run && bun run changeset publish"
   },
   "dependencies": {
     "defu": "^6.1.4",

--- a/src/transformers/link-card/link-card.ts
+++ b/src/transformers/link-card/link-card.ts
@@ -1,7 +1,7 @@
 import { defu } from "defu"
-import type { DeepReadonly, DeepRequired } from "ts-essentials"
 import { unfurl } from "unfurl.js"
 import type { Transformer } from "../../index.js"
+import type { DeepReadonly, DeepRequired } from "../utils.js"
 import type { Element } from "../utils.js"
 import { htmlPreset } from "./presets/html.js"
 
@@ -76,8 +76,9 @@ export type TransformerLinkCardOptions = {
 /**
  * The default options for the {@link transformerLinkCard}.
  */
-export const defaultTransformerLinkCardOptions =
-  htmlPreset() satisfies DeepRequired<DeepReadonly<TransformerLinkCardOptions>>
+export const defaultTransformerLinkCardOptions: DeepRequired<
+  DeepReadonly<TransformerLinkCardOptions>
+> = htmlPreset()
 
 /**
  * A transformer to generate link cards.

--- a/src/transformers/link-card/presets/html.ts
+++ b/src/transformers/link-card/presets/html.ts
@@ -1,5 +1,5 @@
 import { defu } from "defu"
-import type { DeepReadonly, DeepRequired } from "ts-essentials"
+import type { DeepReadonly, DeepRequired } from "../../utils.js"
 import { h } from "../../utils.js"
 import type { LinkInfo, TransformerLinkCardOptions } from "../link-card.js"
 
@@ -91,68 +91,68 @@ export const defaultHtmlPresetOptions: Required<Readonly<HtmlPresetOptions>> = {
  * </p>
  * ```
  */
-export const htmlPreset = (_options?: Readonly<HtmlPresetOptions>) => {
+export const htmlPreset = (
+  _options?: Readonly<HtmlPresetOptions>,
+): DeepRequired<DeepReadonly<TransformerLinkCardOptions>> => {
   const options = defu(_options, defaultHtmlPresetOptions)
 
   return {
     tagName: () => "a",
-    properties: (info) =>
-      ({
-        className: options.classNamePrefix,
-        href: info.url,
-        ...(options.openInNewTab && {
-          target: "_blank",
-          rel: "noopener noreferrer",
-        }),
-      }) as const,
-    children: (info) =>
-      [
+    properties: (info) => ({
+      className: options.classNamePrefix,
+      href: info.url,
+      ...(options.openInNewTab && {
+        target: "_blank",
+        rel: "noopener noreferrer",
+      }),
+    }),
+    children: (info) => [
+      h(
+        "div",
+        { className: `${options.classNamePrefix}__container` },
         h(
           "div",
-          { className: `${options.classNamePrefix}__container` },
+          { className: `${options.classNamePrefix}__info` },
           h(
             "div",
-            { className: `${options.classNamePrefix}__info` },
+            { className: `${options.classNamePrefix}__title` },
+            info.title,
+          ),
+          info.description &&
             h(
               "div",
-              { className: `${options.classNamePrefix}__title` },
-              info.title,
+              { className: `${options.classNamePrefix}__description` },
+              info.description,
             ),
-            info.description &&
-              h(
-                "div",
-                { className: `${options.classNamePrefix}__description` },
-                info.description,
-              ),
+          h(
+            "div",
+            { className: `${options.classNamePrefix}__link` },
+            h("img", {
+              className: `${options.classNamePrefix}__favicon`,
+              src: info.favicon,
+              alt: options.faviconAlt(info),
+              loading: options.imageLoading,
+              decoding: options.imageDecoding,
+            }),
             h(
-              "div",
-              { className: `${options.classNamePrefix}__link` },
-              h("img", {
-                className: `${options.classNamePrefix}__favicon`,
-                src: info.favicon,
-                alt: options.faviconAlt(info),
-                loading: options.imageLoading,
-                decoding: options.imageDecoding,
-              }),
-              h(
-                "span",
-                { className: `${options.classNamePrefix}__hostname` },
-                new URL(info.url).hostname,
-              ),
+              "span",
+              { className: `${options.classNamePrefix}__hostname` },
+              new URL(info.url).hostname,
             ),
           ),
-          info.image.src &&
-            h(
-              "div",
-              { className: `${options.classNamePrefix}__image` },
-              h("img", {
-                src: info.image.src,
-                alt: info.image.alt,
-                loading: options.imageLoading,
-                decoding: options.imageDecoding,
-              }),
-            ),
         ),
-      ] as const,
-  } as const satisfies DeepRequired<DeepReadonly<TransformerLinkCardOptions>>
+        info.image.src &&
+          h(
+            "div",
+            { className: `${options.classNamePrefix}__image` },
+            h("img", {
+              src: info.image.src,
+              alt: info.image.alt,
+              loading: options.imageLoading,
+              decoding: options.imageDecoding,
+            }),
+          ),
+      ),
+    ],
+  }
 }

--- a/src/transformers/oembed/oembed.ts
+++ b/src/transformers/oembed/oembed.ts
@@ -1,10 +1,10 @@
 import { defu } from "defu"
 import type { ElementContent } from "hast"
 import { fromHtmlIsomorphic } from "hast-util-from-html-isomorphic"
-import type { DeepReadonly, DeepRequired } from "ts-essentials"
 import { unfurl } from "unfurl.js"
 import * as v from "valibot"
 import type { Transformer } from "../../index.js"
+import type { DeepReadonly, DeepRequired } from "../utils.js"
 import type { Element } from "../utils.js"
 import type {
   OEmbed,
@@ -117,7 +117,9 @@ export type TransformerOEmbedOptions = {
   ) => Element
 }
 
-export const defaultTransformerOEmbedOptions = {
+export const defaultTransformerOEmbedOptions: DeepRequired<
+  DeepReadonly<TransformerOEmbedOptions>
+> = {
   providers: {
     // https://developer.x.com/en/docs/x-for-websites/oembed-api
     "twitter.com": {
@@ -169,7 +171,7 @@ export const defaultTransformerOEmbedOptions = {
       },
       children: [{ type: "text", value: url.href }],
     }) as const,
-} as const satisfies DeepRequired<DeepReadonly<TransformerOEmbedOptions>>
+}
 
 /**
  * A transformer for oEmbed.
@@ -278,7 +280,7 @@ export const transformerOEmbed = (
   }
 }
 
-const html2hast = (html: string) => {
+const html2hast = (html: string): ElementContent[] => {
   const hast = fromHtmlIsomorphic(html, {
     fragment: true,
   }).children

--- a/src/transformers/oembed/schema.test-d.ts
+++ b/src/transformers/oembed/schema.test-d.ts
@@ -1,0 +1,51 @@
+import type * as v from "valibot"
+import { describe, expectTypeOf, test } from "vitest"
+import type {
+  OEmbed,
+  OEmbedBase,
+  OEmbedBaseSchema,
+  OEmbedLink,
+  OEmbedLinkSchema,
+  OEmbedPhoto,
+  OEmbedPhotoSchema,
+  OEmbedRich,
+  OEmbedRichSchema,
+  OEmbedSchema,
+  OEmbedVideo,
+  OEmbedVideoSchema,
+} from "./schemas.js"
+
+describe("OEmbed schema types", () => {
+  test("OEmbed base schema type", () => {
+    type OEmbedBaseSchemaOutput = v.InferOutput<typeof OEmbedBaseSchema>
+    expectTypeOf<OEmbedBaseSchemaOutput>().toEqualTypeOf<OEmbedBase>()
+  })
+
+  test("OEmbed photo schema type", () => {
+    type OEmbedPhotoSchemaOutput = v.InferOutput<typeof OEmbedPhotoSchema>
+
+    // Without `.branded`, following expectation will fail.
+    // See: https://github.com/vitest-dev/vitest/issues/4114#issuecomment-2265570767
+    expectTypeOf<OEmbedPhotoSchemaOutput>().branded.toEqualTypeOf<OEmbedPhoto>()
+  })
+
+  test("OEmbed video schema type", () => {
+    type OEmbedVideoSchemaOutput = v.InferOutput<typeof OEmbedVideoSchema>
+    expectTypeOf<OEmbedVideoSchemaOutput>().branded.toEqualTypeOf<OEmbedVideo>()
+  })
+
+  test("OEmbed link schema type", () => {
+    type OEmbedLinkSchemaOutput = v.InferOutput<typeof OEmbedLinkSchema>
+    expectTypeOf<OEmbedLinkSchemaOutput>().branded.toEqualTypeOf<OEmbedLink>()
+  })
+
+  test("OEmbed rich schema type", () => {
+    type OEmbedRichSchemaOutput = v.InferOutput<typeof OEmbedRichSchema>
+    expectTypeOf<OEmbedRichSchemaOutput>().branded.toEqualTypeOf<OEmbedRich>()
+  })
+
+  test("OEmbed schemas type", () => {
+    type OEmbedSchemaOutput = v.InferOutput<typeof OEmbedSchema>
+    expectTypeOf<OEmbedSchemaOutput>().branded.toEqualTypeOf<OEmbed>()
+  })
+})

--- a/src/transformers/oembed/schemas.ts
+++ b/src/transformers/oembed/schemas.ts
@@ -1,6 +1,17 @@
 import * as v from "valibot"
 
-const OEmbedBaseSchema = v.object({
+export type OEmbedBase = {
+  version: string
+  title?: string | undefined
+  author_name?: string | undefined
+  author_url?: string | undefined
+  provider_name?: string | undefined
+  provider_url?: string | undefined
+  cache_age?: number | undefined
+  thumbnails?: [{ url?: string; width?: number; height?: number }] | undefined
+}
+
+export const OEmbedBaseSchema = v.object({
   version: v.string(),
   title: v.optional(v.string()),
   author_name: v.optional(v.string()),
@@ -21,7 +32,7 @@ const OEmbedBaseSchema = v.object({
   ),
 })
 
-const OEmbedPhotoSchema = v.object({
+export const OEmbedPhotoSchema = v.object({
   ...OEmbedBaseSchema.entries,
   type: v.literal("photo"),
   url: v.string(),
@@ -29,9 +40,14 @@ const OEmbedPhotoSchema = v.object({
   height: v.number(),
 })
 
-export type OEmbedPhoto = v.InferOutput<typeof OEmbedPhotoSchema>
+export type OEmbedPhoto = OEmbedBase & {
+  type: "photo"
+  url: string
+  width: number
+  height: number
+}
 
-const OEmbedVideoSchema = v.object({
+export const OEmbedVideoSchema = v.object({
   ...OEmbedBaseSchema.entries,
   type: v.literal("video"),
   html: v.string(),
@@ -39,16 +55,23 @@ const OEmbedVideoSchema = v.object({
   height: v.number(),
 })
 
-export type OEmbedVideo = v.InferOutput<typeof OEmbedVideoSchema>
+export type OEmbedVideo = OEmbedBase & {
+  type: "video"
+  html: string
+  width: number
+  height: number
+}
 
-const OEmbedLinkSchema = v.object({
+export const OEmbedLinkSchema = v.object({
   ...OEmbedBaseSchema.entries,
   type: v.literal("link"),
 })
 
-export type OEmbedLink = v.InferOutput<typeof OEmbedLinkSchema>
+export type OEmbedLink = OEmbedBase & {
+  type: "link"
+}
 
-const OEmbedRichSchema = v.object({
+export const OEmbedRichSchema = v.object({
   ...OEmbedBaseSchema.entries,
   type: v.literal("rich"),
   html: v.string(),
@@ -59,7 +82,12 @@ const OEmbedRichSchema = v.object({
   height: v.nullable(v.number()),
 })
 
-export type OEmbedRich = v.InferOutput<typeof OEmbedRichSchema>
+export type OEmbedRich = OEmbedBase & {
+  type: "rich"
+  html: string
+  width: number | null
+  height: number | null
+}
 
 export const OEmbedSchema = v.union([
   OEmbedPhotoSchema,
@@ -68,4 +96,4 @@ export const OEmbedSchema = v.union([
   OEmbedRichSchema,
 ])
 
-export type OEmbed = v.InferOutput<typeof OEmbedSchema>
+export type OEmbed = OEmbedPhoto | OEmbedVideo | OEmbedLink | OEmbedRich

--- a/src/transformers/utils.test-d.ts
+++ b/src/transformers/utils.test-d.ts
@@ -1,0 +1,177 @@
+import { describe, expectTypeOf, test } from "vitest"
+import type { DeepReadonly, DeepRequired } from "./utils.js"
+
+describe("DeepRequired", () => {
+  test("should not work with primitives", () => {
+    type Input = {
+      a?: boolean
+      b?: number
+      c?: string
+      d?: undefined
+      e?: null
+      f?: symbol
+      g?: bigint
+      h?: true
+      i?: 1
+      j?: "string"
+    }
+    type Expected = {
+      a: boolean
+      b: number
+      c: string
+      d: never
+      e: null
+      f: symbol
+      g: bigint
+      h: true
+      i: 1
+      j: "string"
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with nested objects", () => {
+    type Input = {
+      a?: {
+        b?: {
+          c?: number
+        }
+      }
+      d?: {
+        e?: string[]
+      }
+    }
+    type Expected = {
+      a: {
+        b: {
+          c: number
+        }
+      }
+      d: {
+        e: string[]
+      }
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with arrays and tuples", () => {
+    type Input = {
+      arr?: Array<{ a?: number }>
+      tuple?: [boolean?, string?]
+    }
+    type Expected = {
+      arr: Array<{ a: number }>
+      tuple: [boolean, string]
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with Map and Set", () => {
+    type Input = {
+      map?: Map<string, { a?: number }>
+      set?: Set<{ b?: boolean }>
+    }
+    type Expected = {
+      map: Map<string, { a: number }>
+      set: Set<{ b: boolean }>
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with functions", () => {
+    type Input = {
+      fn?: (param?: { a?: number }) => { b?: string }
+    }
+    type Expected = {
+      fn: (param?: { a?: number }) => { b?: string }
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should remove undefined from union types", () => {
+    type Input = {
+      value?: string | undefined
+    }
+    type Expected = {
+      value: string
+    }
+    type Actual = DeepRequired<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+})
+
+describe("DeepReadonly", () => {
+  test("should convert object properties to readonly", () => {
+    type Input = {
+      a: number
+      b: string
+    }
+    type Expected = {
+      readonly a: number
+      readonly b: string
+    }
+    type Actual = DeepReadonly<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with nested objects", () => {
+    type Input = {
+      a: {
+        b: {
+          c: number
+        }
+      }
+    }
+    type Expected = {
+      readonly a: {
+        readonly b: {
+          readonly c: number
+        }
+      }
+    }
+    type Actual = DeepReadonly<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with arrays and tuples", () => {
+    type Input = {
+      arr: Array<{ a: number }>
+      tuple: [boolean, string]
+    }
+    type Expected = {
+      readonly arr: readonly { readonly a: number }[]
+      readonly tuple: readonly [boolean, string]
+    }
+    type Actual = DeepReadonly<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with Map and Set", () => {
+    type Input = {
+      map: Map<string, { a: number }>
+      set: Set<{ b: boolean }>
+    }
+    type Expected = {
+      readonly map: ReadonlyMap<string, { readonly a: number }>
+      readonly set: ReadonlySet<{ readonly b: boolean }>
+    }
+    type Actual = DeepReadonly<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
+  test("should work with functions", () => {
+    type Input = {
+      fn: (param: { a: number }) => { b: string }
+    }
+    type Expected = {
+      readonly fn: (param: { a: number }) => { b: string }
+    }
+    type Actual = DeepReadonly<Input>
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+})

--- a/src/transformers/utils.ts
+++ b/src/transformers/utils.ts
@@ -1,5 +1,4 @@
 import type { ElementContent, Properties } from "hast"
-import type { DeepReadonly } from "ts-essentials"
 
 export type Element = {
   /**
@@ -62,3 +61,11 @@ type FilterChildren<Children extends Child[]> = Children extends [
     ? FilterChildren<Rest>
     : [First, ...FilterChildren<Rest>]
   : []
+
+export type DeepRequired<T extends object> = {
+  [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K]
+}
+
+export type DeepReadonly<T extends object> = {
+  readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K]
+}

--- a/src/transformers/utils.ts
+++ b/src/transformers/utils.ts
@@ -62,10 +62,32 @@ type FilterChildren<Children extends Child[]> = Children extends [
     : [First, ...FilterChildren<Rest>]
   : []
 
-export type DeepRequired<T extends object> = {
-  [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K]
-}
+export type DeepRequired<T> = T extends Record<
+  string | number | symbol,
+  unknown
+>
+  ? { [K in keyof T]-?: DeepRequired<T[K]> }
+  : T extends Array<infer U>
+    ? U[] extends T
+      ? Array<DeepRequired<U>>
+      : { [K in keyof T]-?: DeepRequired<T[K]> }
+    : T extends Map<infer K, infer V>
+      ? Map<DeepRequired<K>, DeepRequired<V>>
+      : T extends Set<infer U>
+        ? Set<DeepRequired<U>>
+        : T
 
-export type DeepReadonly<T extends object> = {
-  readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K]
-}
+export type DeepReadonly<T> = T extends Record<
+  string | number | symbol,
+  unknown
+>
+  ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+  : T extends Array<infer U>
+    ? U[] extends T
+      ? ReadonlyArray<DeepReadonly<U>>
+      : { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T extends Map<infer K, infer V>
+      ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+      : T extends Set<infer U>
+        ? ReadonlySet<DeepReadonly<U>>
+        : T

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     testTimeout: 15 * 1000,
+    typecheck: {
+      enabled: true,
+    },
     environment: "happy-dom",
     setupFiles: ["./vitest.setup.ts"],
   },


### PR DESCRIPTION
close #176 

## Summary

This pull request includes multiple changes aimed at simplifying the codebase, removing unnecessary dependencies, and improving type safety. The most important changes include the removal of `ts-essentials` dependency, updates to the `link-card` and `oembed` transformers, and modifications to the CI workflow.

### Dependency and Type Updates:
* Removed `ts-essentials` dependency from `package.json` and replaced its types with local implementations in `src/transformers/utils.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85) [[2]](diffhunk://#diff-7f393a7b067f563db8539facdf1fe9476786b8461394acb4244b28a9287e62ffL2) [[3]](diffhunk://#diff-7f393a7b067f563db8539facdf1fe9476786b8461394acb4244b28a9287e62ffR64-R71)
* Updated type definitions and schemas in `src/transformers/oembed/schemas.ts` and added corresponding tests in `src/transformers/oembed/schema.test-d.ts`. [[1]](diffhunk://#diff-a52e8e36ff12c8fe580376a2555f3c878cce4e7db942ede752c6496b283c566bL3-R14) [[2]](diffhunk://#diff-a52e8e36ff12c8fe580376a2555f3c878cce4e7db942ede752c6496b283c566bL24-R74) [[3]](diffhunk://#diff-a52e8e36ff12c8fe580376a2555f3c878cce4e7db942ede752c6496b283c566bL62-R90) [[4]](diffhunk://#diff-a52e8e36ff12c8fe580376a2555f3c878cce4e7db942ede752c6496b283c566bL71-R99) [[5]](diffhunk://#diff-5328e64fbee0b2402b379c5743cddb8eb833ffd21c05d5b0eb290801415ab78eR1-R51)

### Workflow and Build Script Updates:
* Removed `--allow-slow-types` flag from various `bun run jsr publish` commands in `.github/workflows/changeset-version.yml`, `.github/workflows/ci.yml`, and `package.json`. [[1]](diffhunk://#diff-ce072a75664f3aabd61e8604723c426c6242e65ce62cda5a6787eea5f4f33589L47-R47) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL65-R65) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L54-R54)
* Enabled type checking in `vitest.config.ts` to ensure better type safety during tests.

### Transformer Updates:
* Refactored `link-card` transformer to use local type definitions and updated the default options format. [[1]](diffhunk://#diff-f2925f5ab734ddcb6df0b836824692cf7b9bb2edcec7b03e9c99fe528d04652dL2-R4) [[2]](diffhunk://#diff-f2925f5ab734ddcb6df0b836824692cf7b9bb2edcec7b03e9c99fe528d04652dL79-R81) [[3]](diffhunk://#diff-9876fda656df2a128e759e5431b4adc9a54f0121f5514d6e205d121333ddca14L2-R2) [[4]](diffhunk://#diff-9876fda656df2a128e759e5431b4adc9a54f0121f5514d6e205d121333ddca14L94-R109) [[5]](diffhunk://#diff-9876fda656df2a128e759e5431b4adc9a54f0121f5514d6e205d121333ddca14L156-R157)
* Refactored `oembed` transformer to use local type definitions and updated the default options format. [[1]](diffhunk://#diff-1a52b5f95753a499be580fe6044b75979765b55f6a50ca6653001b46312d9dc3L4-R7) [[2]](diffhunk://#diff-1a52b5f95753a499be580fe6044b75979765b55f6a50ca6653001b46312d9dc3L120-R122) [[3]](diffhunk://#diff-1a52b5f95753a499be580fe6044b75979765b55f6a50ca6653001b46312d9dc3L172-R174) [[4]](diffhunk://#diff-1a52b5f95753a499be580fe6044b75979765b55f6a50ca6653001b46312d9dc3L281-R283)